### PR TITLE
LD_LIBRARY_PATH is not necessary in .travis.yml

### DIFF
--- a/source/guide.md
+++ b/source/guide.md
@@ -328,6 +328,4 @@ install:
 script:
   - cargo build --verbose
   - cargo test --verbose
-env:
-  - LD_LIBRARY_PATH=/usr/local/lib
 ```


### PR DESCRIPTION
`rustup.sh` defaults to installing in `/usr/lib`, not `/usr/lib/local`.
