### PR TITLE
Updated library section

### DIFF
--- a/source/manifest.md
+++ b/source/manifest.md
@@ -110,7 +110,7 @@ When you run `cargo test`, Cargo will:
   <library-name>` like any other code that depends on it.
 * Compile your library's examples.
 
-# Building Dynamic Libraries
+# Building Libraries
 
 If your project produces a library, you can specify which kind of
 library to build by explicitly listing the library in your `Cargo.toml`:
@@ -118,13 +118,13 @@ library to build by explicitly listing the library in your `Cargo.toml`:
 ```toml
 # ...
 
-[[lib]]
+[lib]
 
 name = "..."
-crate-types = [ "dylib" ]
+crate-type = [ "dylib" ]
 ```
 
-The available options are `dylib` and `rlib`. You should only use
-this option in a project. Cargo will always compile **packages**
+The available options are `dylib`, `rlib`, `staticlib`. You should only 
+use this option in a project. Cargo will always compile **packages**
 (dependencies) based on the requirements of the project that includes
 them.


### PR DESCRIPTION
- `[[lib]]` is deprecated in favor of `[lib]`
- `crate-types` -> `crate-type`
- added `staticlib` 
